### PR TITLE
Updated Commands on README.md which were not working

### DIFF
--- a/Complain_Management_System/requirements.txt
+++ b/Complain_Management_System/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.2.7
 Django==3.0.5
 django-crispy-forms==1.9.0
-Pillow==7.1.1
+Pillow==9.0.1
 pytz==2019.3
 sqlparse==0.3.1

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 2. Create and active virtual environment using  <br>
 ` virtualenv -p python3 env` <br>
-` cd venv` <br>
-`source bin/activate` <br>
+` cd env/Scripts` <br>
+`activate.bat` <br>
 3. Change the directory using <br>
 `cd ..` <br>
 ` cd Complain_Management_System`<br>


### PR DESCRIPTION
# Fixed some cmd that were not working

### Activating virtual environment was not working `source bin/activate` instead 
####  ``cd env/Scripts ``
####  ``activate.bat``
### And `cd venv` is not the folder that is created when creating virtual environment, it's just `env`

